### PR TITLE
Create Nanite Integration (Repairing Nanites)

### DIFF
--- a/Nanite Integration (Repairing Nanites)
+++ b/Nanite Integration (Repairing Nanites)
@@ -1,0 +1,48 @@
+main ()
+
+async function main() {
+  //Is a single token selected?
+  console.log("Selected Token: ", canvas.tokens.controlled);
+  if(canvas.tokens.controlled.length == 0 || canvas.tokens.controlled.length > 1) {
+    ui.notifications.error("Please select a single token");
+    return;
+  }
+  const user = canvas.tokens.controlled[0].actor;
+  
+  //Does user have the Nanite Integration feat?
+  console.log("User of Repairing Nanites: ", user);
+  const nanites = user.items.find(items => items.name == "Nanite Integration");
+   if(nanites == null || nanites == undefined) {
+     ui.notifications.error(`${actor.data.name} does not possess Nanite Integration`);
+     return;
+  }
+  
+  // Determines the number of rounds
+  let min = nanites.system.uses.value;
+  let minmax = nanites.system.uses.max;
+  
+  //Determines the intensity of the fast healing
+  let healfactor = user.system.details.level.value;
+  healfactor = healfactor/4;
+  if(healfactor < 1)
+    healfactor = 1;
+  let healing = user.system.attributes.hp.value + healfactor;
+  const maxhp = user.system.attributes.hp.max;
+
+  if (nanites.isActive() == true)
+  //If there is still time, inform user of how long left and how much healing they get every round, else inform them that it has expired.
+  if(min > 0) {
+    ui.notifications.warn(`Seconds left of fast healing ${healing}: ${min*6}`);
+    if(healing >= maxhp) {
+      healing = maxhp;
+    }
+    min--;
+    nanites.update({"system.uses.value": min});
+    user.update({"system.attributes.hp.value": healing});
+  }
+  else if(min == 0) {
+    ui.notifications.info(`Fast Healing has expired`);
+    nanites.setActive(false);
+    nanites.update({"system.uses.value": minmax});
+  }
+}

--- a/Nanite Integration (Repairing Nanites)
+++ b/Nanite Integration (Repairing Nanites)
@@ -1,3 +1,11 @@
+// Recommended that you set Activation Cost to Reaction and the Limited Uses to 11/11.
+// It uses one when activating the ability and then drains 1 each time macro is activated.
+// When it reaches zero, it will turn itself off and set it back to maximum value.
+
+// Will not work with multiple tokens selected.
+// Will require that the user has the feat Nanite Integration.
+// If you change the name of the feat to reflect your choice, reflect the name change at line 22.
+
 main ()
 
 async function main() {


### PR DESCRIPTION
Recommended that you Activation Cost to Reaction and the Limited Uses to 11/11, as it uses one when activating the ability and then drains 1 per round until it reaches zero at which point it will turn itself off and set it back to maximum value.